### PR TITLE
add diff, LSP semantic tokens, LSP references colors

### DIFF
--- a/lua/boo-colorscheme.lua
+++ b/lua/boo-colorscheme.lua
@@ -443,8 +443,6 @@ local treesitter = function(c)
 
 			{ "TSVariableBuiltin", c.cloud12:lighten_to(0.4) },
 
-			{ "TSComment", c.cloud14:desaturate_to(0.2):lighten_to(0.5) },
-
 			{ "TSField", c.cloud8 },
 
 			{ "TSNodeKey", c.cloud10 },
@@ -453,6 +451,7 @@ local treesitter = function(c)
 	})
 end
 
+-- Temporary migration until we port over to the new names (and backport for older versions of Neovim)
 local treesitter_migrate = function()
 	local map = {
 		["annotation"] = "TSAnnotation",
@@ -564,6 +563,94 @@ local treesitter_migrate = function()
 
 	for capture, hlgroup in pairs(map) do
 		vim.api.nvim_set_hl(0, "@" .. capture, { link = hlgroup, default = true })
+	end
+
+	local defaults = {
+		TSNone = { default = true },
+		TSPunctDelimiter = { link = "Delimiter", default = true },
+		TSPunctBracket = { link = "Delimiter", default = true },
+		TSPunctSpecial = { link = "Delimiter", default = true },
+
+		TSConstant = { link = "Constant", default = true },
+		TSConstBuiltin = { link = "Special", default = true },
+		TSConstMacro = { link = "Define", default = true },
+		TSString = { link = "String", default = true },
+		TSStringRegex = { link = "String", default = true },
+		TSStringEscape = { link = "SpecialChar", default = true },
+		TSStringSpecial = { link = "SpecialChar", default = true },
+		TSCharacter = { link = "Character", default = true },
+		TSCharacterSpecial = { link = "SpecialChar", default = true },
+		TSNumber = { link = "Number", default = true },
+		TSBoolean = { link = "Boolean", default = true },
+		TSFloat = { link = "Float", default = true },
+
+		TSFunction = { link = "Function", default = true },
+		TSFunctionCall = { link = "TSFunction", default = true },
+		TSFuncBuiltin = { link = "Special", default = true },
+		TSFuncMacro = { link = "Macro", default = true },
+		TSParameter = { link = "Identifier", default = true },
+		TSParameterReference = { link = "TSParameter", default = true },
+		TSMethod = { link = "Function", default = true },
+		TSMethodCall = { link = "TSMethod", default = true },
+		TSField = { link = "Identifier", default = true },
+		TSProperty = { link = "Identifier", default = true },
+		TSConstructor = { link = "Special", default = true },
+		TSAnnotation = { link = "PreProc", default = true },
+		TSAttribute = { link = "PreProc", default = true },
+		TSNamespace = { link = "Include", default = true },
+		TSSymbol = { link = "Identifier", default = true },
+
+		TSConditional = { link = "Conditional", default = true },
+		TSRepeat = { link = "Repeat", default = true },
+		TSLabel = { link = "Label", default = true },
+		TSOperator = { link = "Operator", default = true },
+		TSKeyword = { link = "Keyword", default = true },
+		TSKeywordFunction = { link = "Keyword", default = true },
+		TSKeywordOperator = { link = "TSOperator", default = true },
+		TSKeywordReturn = { link = "TSKeyword", default = true },
+		TSException = { link = "Exception", default = true },
+		TSDebug = { link = "Debug", default = true },
+		TSDefine = { link = "Define", default = true },
+		TSPreProc = { link = "PreProc", default = true },
+		TSStorageClass = { link = "StorageClass", default = true },
+
+		TSTodo = { link = "Todo", default = true },
+
+		TSType = { link = "Type", default = true },
+		TSTypeBuiltin = { link = "Type", default = true },
+		TSTypeQualifier = { link = "Type", default = true },
+		TSTypeDefinition = { link = "Typedef", default = true },
+
+		TSInclude = { link = "Include", default = true },
+
+		TSVariableBuiltin = { link = "Special", default = true },
+
+		TSText = { link = "TSNone", default = true },
+		TSStrong = { bold = true, default = true },
+		TSEmphasis = { italic = true, default = true },
+		TSUnderline = { underline = true },
+		TSStrike = { strikethrough = true },
+
+		TSMath = { link = "Special", default = true },
+		TSTextReference = { link = "Constant", default = true },
+		TSEnvironment = { link = "Macro", default = true },
+		TSEnvironmentName = { link = "Type", default = true },
+		TSTitle = { link = "Title", default = true },
+		TSLiteral = { link = "String", default = true },
+		TSURI = { link = "Underlined", default = true },
+
+		TSComment = { link = "Comment", default = true },
+		TSNote = { link = "SpecialComment", default = true },
+		TSWarning = { link = "Todo", default = true },
+		TSDanger = { link = "WarningMsg", default = true },
+
+		TSTag = { link = "Label", default = true },
+		TSTagDelimiter = { link = "Delimiter", default = true },
+		TSTagAttribute = { link = "TSProperty", default = true },
+	}
+
+	for group, val in pairs(defaults) do
+		vim.api.nvim_set_hl(0, group, val)
 	end
 end
 

--- a/lua/boo-colorscheme.lua
+++ b/lua/boo-colorscheme.lua
@@ -356,7 +356,7 @@ local treesitter = function(c)
 		"TSConstMacro",
 	}
 
-	local constructors = { { "TSConstructor", link = "@constructor" } }
+	local constructors = { "TSConstructor" }
 
 	local string = { "TSStringRegex", "TSString", "TSStringEscape", "TSStringSpecial" }
 


### PR DESCRIPTION
Internal diff and better support for [diffview.nvim](https://github.com/sindrets/diffview.nvim).
Semantic tokens support [theHamsta/nvim-semantic-tokens](https://github.com/theHamsta/nvim-semantic-tokens) 

LSPDocumentHighlight support

```lua
	if client.server_capabilities.documentHighlightProvider then
		local group = vim.api.nvim_create_augroup("LSPDocumentHighlight", {})

		vim.opt_local.updatetime = 1000

		vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
			buffer = bufnr,
			group = group,
			callback = function()
				vim.lsp.buf.document_highlight()
			end,
		})
		vim.api.nvim_create_autocmd({ "CursorMoved" }, {
			buffer = bufnr,
			group = group,
			callback = function()
				vim.lsp.buf.clear_references()
			end,
		})
	end
```
